### PR TITLE
Reset preview token on Unpublish

### DIFF
--- a/src/Http/DraftController.php
+++ b/src/Http/DraftController.php
@@ -2,6 +2,7 @@
 
 namespace OptimistDigital\NovaDrafts\Http;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use OptimistDigital\NovaDrafts\Models\Draft;
@@ -56,6 +57,7 @@ class DraftController extends Controller
         }
 
         $draftToUnpublish->published = false;
+        $draftToUnpublish->preview_token = Str::random(20);
         $draftToUnpublish->save();
 
         return response('', 204);


### PR DESCRIPTION
If you click the unpublish button, you wont be able to preview specific model, because preview token is `null` after publishing. 

This PR fixes this issue.