### PR TITLE
correcting the error SQLSTATE[HY000]: General error: 1 near "SHOW": syntax error (SQL: SHOW TABLES)

### DIFF
--- a/src/Commands/CreateDraftsMigration.php
+++ b/src/Commands/CreateDraftsMigration.php
@@ -14,11 +14,9 @@ class CreateDraftsMigration extends Command
     protected $signature = 'drafts:migration
                     { table? : Which table you would like to add drafts logic to }';
 
-
     protected $description = 'Add migration for nova-draft package';
 
     protected $tableName, $tables, $className, $files, $path;
-
 
     public function __construct(Filesystem $files)
     {
@@ -45,8 +43,10 @@ class CreateDraftsMigration extends Command
 
     public function getTables()
     {
-        $tables = DB::select('SHOW TABLES');
-        return array_map('current', $tables);
+        $schema = collect(DB::getDoctrineSchemaManager()->listTableNames())->map(function (string $item, int $key) {
+            return $item;
+        });
+        return $schema->all();
     }
 
     /**
@@ -69,7 +69,10 @@ class CreateDraftsMigration extends Command
 
     public function validateInsertedTableName()
     {
-        if (Schema::hasTable($this->argument('table'))) return $this->argument('table');
+        if (Schema::hasTable($this->argument('table'))) {
+            return $this->argument('table');
+        }
+
         $this->error("[ERROR] Table '{$this->argument('table')}' does not exist in your database");
         return $this->getTableChoice();
 
@@ -81,7 +84,10 @@ class CreateDraftsMigration extends Command
         $class_name = join(array_map('ucfirst', explode('_', $class_name)));
         $class_name = "AddNovaDraftsTo{$class_name}";
 
-        if (Schema::hasColumn($this->tableName, 'draft_parent_id')) throw new \Exception("Table '{$this->tableName}' already has drafts");
+        if (Schema::hasColumn($this->tableName, 'draft_parent_id')) {
+            throw new \Exception("Table '{$this->tableName}' already has drafts");
+        }
+
         return $class_name;
     }
 
@@ -112,7 +118,6 @@ class CreateDraftsMigration extends Command
         }
         return $path;
     }
-
 
     /**
      * Create the migration file content.

--- a/src/Commands/CreateDraftsMigration.php
+++ b/src/Commands/CreateDraftsMigration.php
@@ -43,10 +43,7 @@ class CreateDraftsMigration extends Command
 
     public function getTables()
     {
-        $schema = collect(DB::getDoctrineSchemaManager()->listTableNames())->map(function (string $item, int $key) {
-            return $item;
-        });
-        return $schema->all();
+        return DB::getDoctrineSchemaManager()->listTableNames();
     }
 
     /**
@@ -85,7 +82,7 @@ class CreateDraftsMigration extends Command
         $class_name = "AddNovaDraftsTo{$class_name}";
 
         if (Schema::hasColumn($this->tableName, 'draft_parent_id')) {
-            throw new \Exception("Table '{$this->tableName}' already has drafts");
+            throw new \Exception("Table '{$this->tableName}' already has drafts, do you wish to continue?");
         }
 
         return $class_name;


### PR DESCRIPTION
Hello everyone, my name is Jonatas and I'm new to this issue of contributions here at guithub, I found a problem with migration:

```php
✗ php artisan drafts:migration blogs

   Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 1 near "SHOW": syntax error (SQL: SHOW TABLES)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:671
    667▕         // If an exception occurs when attempting to run a query, we'll format the error
    668▕         // message to include the bindings with SQL, which will make this exception a
    669▕         // lot more helpful to the developer instead of just the database's errors.
    670▕         catch (Exception $e) {
  ➜ 671▕             throw new QueryException(
    672▕                 $query, $this->prepareBindings($bindings), $e
    673▕             );
    674▕         }
    675▕ 

      +10 vendor frames 
  11  /var/www/github/nova-drafts/src/Commands/CreateDraftsMigration.php:52
      Illuminate\Support\Facades\Facade::__callStatic()

  12  /var/www/github/nova-drafts/src/Commands/CreateDraftsMigration.php:36
```
For my development environment I am using sqlite, and I believe that this code snippet will fix this error, please evaluate if it is coherent, I will be waiting to be able to have my first contribution.

```php
$schema = collect(DB::getDoctrineSchemaManager()->listTableNames())->map(function (string $item, int $key) {
    return $item;
});
return $schema->all();
```
the code I added was this, about the formatting of the file, if you think it is not necessary, without problems I will remove.

